### PR TITLE
chore: update dependencies

### DIFF
--- a/flutter_cache_manager/example/pubspec.yaml
+++ b/flutter_cache_manager/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: A project that showcases usage of flutter_cache_manager
 publish_to: none
 version: 1.0.0+1
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   baseflow_plugin_template: ^2.2.0
@@ -12,12 +12,12 @@ dependencies:
     sdk: flutter
   flutter_cache_manager:
     path: ../
-  url_launcher: ^6.3.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true

--- a/flutter_cache_manager/pubspec.yaml
+++ b/flutter_cache_manager/pubspec.yaml
@@ -6,27 +6,27 @@ topics:
   - cache
   - cache-manager
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
-  clock: ^1.1.1
-  collection: ^1.18.0
-  file: ^7.0.0
+  clock: ^1.1.2
+  collection: ^1.19.1
+  file: ^7.0.1
   flutter:
     sdk: flutter
-  http: ^1.2.2
-  path: ^1.9.0
-  path_provider: ^2.1.4
-  rxdart: '>=0.27.7 <0.29.0'
-  sqflite: ^2.3.3+1
-  uuid: ^4.4.2
+  http: ^1.5.0
+  path: ^1.9.1
+  path_provider: ^2.1.5
+  rxdart: ^0.28.0
+  sqflite: ^2.4.2
+  uuid: ^4.5.1
 
 dev_dependencies:
-  build_runner: ^2.4.12
-  flutter_lints: ^4.0.0
+  build_runner: ^2.8.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.4
+  mockito: ^5.5.1
 
 platforms:
   android:

--- a/flutter_cache_manager_firebase/pubspec.yaml
+++ b/flutter_cache_manager_firebase/pubspec.yaml
@@ -4,18 +4,18 @@ version: 2.1.1
 homepage: https://github.com/Baseflow/flutter_cache_manager
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: '>=3.8.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.4.1
-  firebase_storage: '>=12.0.0 <13.0.0'
-  path_provider: ^2.1.4
-  path: ^1.9.0
+  firebase_storage: ^13.0.2
+  path_provider: ^2.1.5
+  path: ^1.9.1
   retry: ^3.1.2
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- update `flutter_cache_manager` dependency constraints to the latest pub.dev releases
- align the example and firebase cache manager packages with the new SDK floor and dependency versions

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d52849662c8333a9aaed9718cf13d8